### PR TITLE
Fix master attribute sending and use alternative container for minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+---
 services:
   ripe-updater:
     restart: always
@@ -18,13 +18,18 @@ services:
 
   minio:
     restart: always
-    image: docker.io/bitnami/minio:2024
+    image: coollabsio/minio:latest
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_DEFAULT_BUCKETS: ripe-backups
     volumes:
-      - "minio-data:/bitnami/minio/data"
+      - "minio-data:/data"
+    command: server /data --console-address ":9001"
     networks:
       - ripe-updater
 

--- a/ripe-updater/ripeupdater/main.py
+++ b/ripe-updater/ripeupdater/main.py
@@ -81,7 +81,7 @@ def update():
 
     # ensure valid netbox request
     try:
-        if webhook['model'] != 'prefix':
+        if webhook['object_type'] != 'ipam.prefix':
             msg = 'only prefixes are supported'
             logger.error(msg)
             return msg, 400

--- a/ripe-updater/ripeupdater/ripe.py
+++ b/ripe-updater/ripeupdater/ripe.py
@@ -184,16 +184,16 @@ class RipeObjectManager():
                         templates_fields.append({t_name: t_value})
                     else:
                         self.org = t_value
-                    for m_attribute in master_attributes:
-                        for m_name, m_value in m_attribute.items():
-                            if m_value:
-                                master_fields.append({m_name: m_value})
-                                if m_name in t_attribute.keys() and m_name != 'descr':
-                                    if m_name in t_attribute.keys() and m_name != 'country':
-                                        master_fields.remove({m_name: m_value})
-                                if m_name == 'org':
-                                    self.org = m_value
-                                    master_fields.remove({m_name: m_value})
+        for m_attribute in master_attributes:
+            for m_name, m_value in m_attribute.items():
+                if m_value:
+                    master_fields.append({m_name: m_value})
+                    if m_name in t_attribute.keys() and m_name != 'descr':
+                        if m_name in t_attribute.keys() and m_name != 'country':
+                            master_fields.remove({m_name: m_value})
+                    if m_name == 'org':
+                        self.org = m_value
+                        master_fields.remove({m_name: m_value})
 
         dynamic_attributes = []
 


### PR DESCRIPTION
There was bug, where master attributes were sent multiple times if there was some attribute in template attributes defined more than once (e.g. descr field can be set multiple times).

Also bitnami has no docker containers available for free anymore, so I picked up an alternative.